### PR TITLE
Rework CI database and add publishing workflows

### DIFF
--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -1,0 +1,36 @@
+name: Build and Publish CI Database Docker Image
+
+on:
+  push:
+    branches:
+      - 'master'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./database/ci/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -1,0 +1,36 @@
+name: Build and Publish Demo Database Docker Image
+
+on:
+  push:
+    branches:
+      - 'master'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./database/demo/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:demo

--- a/.github/workflows/publish-liquibase.yml
+++ b/.github/workflows/publish-liquibase.yml
@@ -1,0 +1,35 @@
+name: Build and Publish Liquibase Docker Image
+
+on:
+  push:
+    branches:
+      - 'master'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./liquibase
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:liquibase

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ It will be available on you localhost's port $DB_CI_PORT
 You can also pull the image from the GitHub Package Repository and run it with
 
 ```
-docker run -it --env-file ./.env -p 5445:5432 ghcr.io/acwi-sswd/nldi-db:ci-latest
+docker run -it --env-file ./.env -p 5445:5432 ghcr.io/internetofwater/nldi-db:ci
 ```
 where __./.env__ is the environment variable file you have locally and __5445__ can be changed to the port you wish to access it via.
 
@@ -117,7 +117,7 @@ It will be available on your localhost's port $DB_DEMO_PORT
 You can also pull the image from the GitHub Package Repository and run it with
 
 ```
-docker run -it --env-file ./.env -p 5446:5432/tcp ghcr.io/acwi-sswd/nldi-db:demo-latest
+docker run -it --env-file ./.env -p 5446:5432/tcp ghcr.io/internetofwater/nldi-db:demo
 ```
 
 where __./.env__ is the environment variable file you have locally and __5446__ can be changed to the port you wish to access it via.

--- a/database/ci/Dockerfile
+++ b/database/ci/Dockerfile
@@ -25,6 +25,3 @@ COPY ./liquibase/changeLogs $LIQUIBASE_WORKSPACE
 COPY ./liquibase/scripts/*.sh /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbInit /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbCi /docker-entrypoint-initdb.d/
-
-RUN curl -L --verbose  "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
-RUN curl -L --verbose  "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz

--- a/database/demo/Dockerfile
+++ b/database/demo/Dockerfile
@@ -26,9 +26,9 @@ COPY ./liquibase/scripts/*.sh /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbInit/*.sh /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbDemo/*.sh /docker-entrypoint-initdb.d/
 
-RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
-RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
-RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/nldi_data.crawler_source.pgdump.gz" -o $LIQUIBASE_HOME/nldi_data.crawler_source.pgdump.gz
-RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_wqp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_wqp_yahara.backup.gz
-RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_huc12pp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_huc12pp_yahara.backup.gz
-RUN curl -L --verbose "https://github.com/ACWI-SSWD/nldi-db/releases/download/artifacts-1.0.0/feature_np21_nwis_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_np21_nwis_yahara.backup.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/nldi_data.crawler_source.pgdump.gz" -o $LIQUIBASE_HOME/nldi_data.crawler_source.pgdump.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/feature_wqp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_wqp_yahara.backup.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/feature_huc12pp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_huc12pp_yahara.backup.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/feature_np21_nwis_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_np21_nwis_yahara.backup.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 version: '3.3'
+
 services:
 
   ci:
-    image: nldi-db-ci
+    image: ghcr.io/internetofwater/nldi-db:ci
     build:
       context: .
       dockerfile: ./database/ci/Dockerfile
@@ -27,7 +28,7 @@ services:
     container_name: nldi-db-ci
 
   demo:
-    image: nldi-db-demo
+    image: ghcr.io/internetofwater/nldi-db:demo
     build:
       context: .
       dockerfile: ./database/demo/Dockerfile
@@ -52,7 +53,7 @@ services:
     container_name: nldi-db-demo
 
   db:
-    image: postgis/postgis:12-3.0
+    image: ${DOCKER_MIRROR}postgis/postgis:12-3.0
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${NLDI_DATABASE_NAME}
@@ -61,7 +62,7 @@ services:
     container_name: nldi-db
 
   liquibase:
-    image: nldi-liquibase
+    image: ghcr.io/internetofwater/nldi-db:liquibase
     build:
       context: ./liquibase
       args:
@@ -83,4 +84,4 @@ services:
     volumes:
       - ./liquibase/changeLogs:/liquibase/workspace/
       - ./liquibase/scripts/dbInit:/docker-entrypoint-initdb.d
-    container_name: nldi-liquibase
+    container_name: nldi-db-liquibase

--- a/liquibase/scripts/dbCi/z3_clear_data.sh
+++ b/liquibase/scripts/dbCi/z3_clear_data.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# The CI database should be completely cleared of data.
+# The crawler_source table has data injected from the liquibase
+# changelogs, so it needs to be truncated.
+psql --host=127.0.0.1 \
+	--port=5432 \
+	--username=postgres \
+	--no-password \
+	--dbname=${NLDI_DATABASE_NAME} \
+	--command='truncate table nldi_data.crawler_source;'
+
+exit 0

--- a/liquibase/scripts/dbCi/z3_load_network.sh
+++ b/liquibase/scripts/dbCi/z3_load_network.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-gunzip -c ${LIQUIBASE_HOME}/nhdplus.yahara.pgdump.gz | pg_restore -h 127.0.0.1 -p 5432 -U postgres -w -a -d ${NLDI_DATABASE_NAME}
-gunzip -c ${LIQUIBASE_HOME}/characteristic_data.yahara.pgdump.gz | pg_restore -h 127.0.0.1 -p 5432 -U postgres -w -a -d ${NLDI_DATABASE_NAME} -n characteristic_data


### PR DESCRIPTION
I've adjusted the CI database so that it is completely clear of data. This only required truncating the crawler source table as part of the startup. I've also included GitHub workflows that will publish the latest of each image in this repositories container registry.