### PR TITLE
Add index on identifier for feature tables

### DIFF
--- a/liquibase/changeLogs/nldi/nldi_data/indexes/changeLog.yml
+++ b/liquibase/changeLogs/nldi/nldi_data/indexes/changeLog.yml
@@ -6,5 +6,8 @@ databaseChangeLog:
       username: ${NLDI_SCHEMA_OWNER_USERNAME}
 
   - include:
-      - file: webServiceLogId.yml
-      - relativeToChangelogFile: true
+    - file: webServiceLogId.yml
+    - relativeToChangelogFile: true
+  - include:
+    - file: featureId.yml
+    - relativeToChangelogFile: true

--- a/liquibase/changeLogs/nldi/nldi_data/indexes/featureId.yml
+++ b/liquibase/changeLogs/nldi/nldi_data/indexes/featureId.yml
@@ -1,0 +1,77 @@
+databaseChangeLog:
+  - changeSet: # create primary feature table index on identifier
+      author: egrahn
+      id: "create.index.nldi_data.feature_identifier_idx"
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - sqlCheck:
+            expectedResult: 0
+            sql: select count(*) from pg_catalog.pg_indexes where schemaname = 'nldi_data' and indexname = 'feature_identifier_idx'
+      changes:
+        - sql: create index feature_identifier_idx on nldi_data.feature(identifier);
+        - rollback: drop index if exists nldi_data.feature_identifier_idx;
+  - changeSet: # create index for any existing inherited feature tables
+      author: egrahn
+      id: "create.index.nldi_data.feature_"
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - sqlCheck:
+            expectedResult: false
+            sql: >
+              with
+                idx_count as (
+                  select count(*)
+                  from pg_catalog.pg_indexes
+                  where schemaname = 'nldi_data'
+                  and indexname like 'feature_%_identifier%'
+                ),
+                table_count as (
+                  select count(*)
+                  from pg_catalog.pg_tables
+                  where schemaname= 'nldi_data'
+                  and tablename like 'feature_%'
+                )
+              select idx_count.count = table_count.count
+              from idx_count, table_count
+      changes:
+        - sql:
+            relativeToChangelogFile: true
+            splitStatements: false
+            sql: >
+              do
+              $$
+              declare
+                rec record;
+              begin
+                for rec in 
+                  select table_name
+                  from information_schema.tables
+                  where table_schema = 'nldi_data'
+                  and table_name like 'feature_%'
+                loop
+                  execute format('create index if not exists %I_identifier_idx on nldi_data.%I(identifier);', rec.table_name, rec.table_name);
+                end loop;
+              end;
+              $$ language plpgsql
+        - rollback:
+            - sql:
+                relativeToChangelogFile: true
+                splitStatements: false
+                sql: >
+                  do
+                  $$
+                  declare
+                    rec record
+                  begin
+                    for rec in 
+                      select table_name
+                      from information_schema.tables
+                      where table_schema = 'nldi_data'
+                      and table_name like 'feature_%'
+                    loop
+                      execute format('drop index if exists %I_identifier_idx;', rec.table_name)
+                    end loop
+                  end
+                  $$ language plpgsql


### PR DESCRIPTION
Added a new index for `nldi_data.feature` tables on the `identifier` column. I have also included a change set that loops over any existing feature tables and adds the index. This is necessary for any currently deployed databases because the change to the parent table will not propagate to the child tables.

Closes #92 