### PR TITLE
Use f instead of false in precondition

### DIFF
--- a/liquibase/changeLogs/nldi/nldi_data/indexes/featureId.yml
+++ b/liquibase/changeLogs/nldi/nldi_data/indexes/featureId.yml
@@ -18,7 +18,7 @@ databaseChangeLog:
         - onFail: MARK_RAN
         - onError: HALT
         - sqlCheck:
-            expectedResult: false
+            expectedResult: f
             sql: >
               with
                 idx_count as (


### PR DESCRIPTION
The precondition was checking for a false result, but `f` is the actual result.