### PR TITLE
Fix crawler source ids for demo database

### DIFF
--- a/database/demo/Dockerfile
+++ b/database/demo/Dockerfile
@@ -23,19 +23,16 @@ RUN apt-get update && apt-get install -y curl
 ############################################
 
 COPY ./liquibase/changeLogs $LIQUIBASE_WORKSPACE
-COPY ./database/demo/crawler_source.tsv $LIQUIBASE_WORKSPACE/nldi/nldi_data/update_crawler_source/crawler_source.tsv
 COPY ./liquibase/scripts/*.sh /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbInit/*.sh /docker-entrypoint-initdb.d/
 COPY ./liquibase/scripts/dbDemo/*.sh /docker-entrypoint-initdb.d/
 
-RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
-RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
-RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/nldi_data.crawler_source.pgdump.gz" -o $LIQUIBASE_HOME/nldi_data.crawler_source.pgdump.gz
-RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/feature_wqp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_wqp_yahara.backup.gz
-RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/feature_huc12pp_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_huc12pp_yahara.backup.gz
-RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/feature_np21_nwis_yahara.backup.gz" -o $LIQUIBASE_HOME/feature_np21_nwis_yahara.backup.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-2.0.0/crawler_source.yahara.tsv" -o $LIQUIBASE_HOME/nldi/nldi_data/update_crawler_source/crawler_source.tsv
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-2.0.0/mainstem_lookup.yahara.csv" -o $LIQUIBASE_HOME/mainstem_lookup.csv
 
-ARG MAINSTEM_COMMIT="9052cbaeccbaa88f91317f8ec9891a90d378371f"
-RUN curl -L "https://code.usgs.gov/wma/nhgf/gfv2.0/-/raw/${MAINSTEM_COMMIT}/workspace/data/mainstem_lookup.csv.gz?inline=false" \
-	-o ${LIQUIBASE_HOME}/mainstem_lookup.csv.gz
-RUN gunzip ${LIQUIBASE_HOME}/mainstem_lookup.csv.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-2.0.0/nhdplus.yahara.pgdump.gz" -o $LIQUIBASE_HOME/nhdplus.yahara.pgdump.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-2.0.0/characteristic_data.yahara.pgdump.gz" -o $LIQUIBASE_HOME/characteristic_data.yahara.pgdump.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-2.0.0/feature_wqp.yahara.pgdump.gz" -o $LIQUIBASE_HOME/feature_wqp.yahara.pgdump.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-2.0.0/feature_huc12pp.yahara.pgdump.gz" -o $LIQUIBASE_HOME/feature_huc12pp.yahara.pgdump.gz
+RUN curl -L --verbose "https://github.com/internetofwater/nldi-db/releases/download/artifacts-2.0.0/feature_nwissite.yahara.pgdump.gz" -o $LIQUIBASE_HOME/feature_nwissite.yahara.pgdump.gz
+

--- a/database/demo/crawler_source.tsv
+++ b/database/demo/crawler_source.tsv
@@ -1,4 +1,0 @@
-crawler_source_id	source_name	source_suffix	source_uri	feature_id	feature_name	feature_uri	feature_reach	feature_measure	ingest_type	feature_type
-1	Water Quality Portal	WQP	https://www.waterqualitydata.us/data/Station/search?mimeType=geojson&minactivities=1&counts=no	MonitoringLocationIdentifier	MonitoringLocationName	siteUrl	NULL	NULL	point	varies
-3	NWIS Surface Water Sites	nwissite	https://www.sciencebase.gov/catalog/file/get/60c7b895d34e86b9389b2a6c?name=usgs_nldi_gages.geojson	provider_id	name	subjectOf	nhdpv2_REACHCODE	nhdpv2_REACH_measure	reach	hydrolocation
-4	HUC12 Pour Points	huc12pp	https://www.sciencebase.gov/catalogMaps/mapping/ows/57336b02e4b0dae0d5dd619a?service=WFS&version=1.0.0&request=GetFeature&srsName=EPSG:4326&typeName=sb:fpp&outputFormat=json	HUC_12	HUC_12	HUC_12	NULL	NULL	point	hydrolocation

--- a/liquibase/changeLogs/nldi/nldi_data/tables.sql
+++ b/liquibase/changeLogs/nldi/nldi_data/tables.sql
@@ -50,12 +50,12 @@ create table nldi_data.feature_wqp ( ) inherits (nldi_data.feature);
 alter table nldi_data.feature_wqp owner to ${NLDI_SCHEMA_OWNER_USERNAME};
 --rollback drop table nldi_data.feature_wqp;
 
---changeset drsteini:create.nldi_data.feature_np21_nwis
+--changeset drsteini:create.nldi_data.feature_nwissite
 --preconditions onFail:MARK_RAN onError:HALT
---precondition-sql-check expectedResult:0 select count(*) from information_schema.tables where table_schema = 'nldi_data' and table_name = 'feature_np21_nwis'
-create table nldi_data.feature_np21_nwis ( ) inherits (nldi_data.feature);
-alter table nldi_data.feature_np21_nwis owner to ${NLDI_SCHEMA_OWNER_USERNAME};
---rollback drop table nldi_data.feature_np21_nwis;
+--precondition-sql-check expectedResult:0 select count(*) from information_schema.tables where table_schema = 'nldi_data' and table_name = 'feature_nwissite'
+create table nldi_data.feature_nwissite ( ) inherits (nldi_data.feature);
+alter table nldi_data.feature_nwissite owner to ${NLDI_SCHEMA_OWNER_USERNAME};
+--rollback drop table nldi_data.feature_nwissite;
 
 --changeset drsteini:create.nldi_data.sqlinjection_test context:ci
 --preconditions onFail:MARK_RAN onError:HALT
@@ -92,10 +92,10 @@ alter table nldi_data.web_service_log owner to ${NLDI_SCHEMA_OWNER_USERNAME};
 --precondition-sql-check expectedResult:t select to_regclass('nldi_data.feature_wqp_temp') is not null
 drop table nldi_data.feature_wqp_temp;
 
---changeset egrahn:drop.nldi_data.feature_np21_nwis_temp
+--changeset egrahn:drop.nldi_data.feature_nwissite_temp
 --preconditions onFail:MARK_RAN onError:HALT
---precondition-sql-check expectedResult:t select to_regclass('nldi_data.feature_np21_nwis_temp') is not null
-drop table nldi_data.feature_np21_nwis_temp;
+--precondition-sql-check expectedResult:t select to_regclass('nldi_data.feature_nwissite_temp') is not null
+drop table nldi_data.feature_nwissite_temp;
 
 --changeset egrahn:drop.nldi_data.sqlinjection_test_temp
 --preconditions onFail:MARK_RAN onError:HALT

--- a/liquibase/scripts/dbDemo/z4_load_demo.sh
+++ b/liquibase/scripts/dbDemo/z4_load_demo.sh
@@ -2,7 +2,6 @@
 
 gunzip -c ${LIQUIBASE_HOME}/nhdplus.yahara.pgdump.gz | pg_restore -h 127.0.0.1 -p 5432 -U postgres -w -a -d ${NLDI_DATABASE_NAME}
 gunzip -c ${LIQUIBASE_HOME}/characteristic_data.yahara.pgdump.gz | pg_restore -h 127.0.0.1 -p 5432 -U postgres -w -a -d ${NLDI_DATABASE_NAME} -n characteristic_data
-gunzip -c ${LIQUIBASE_HOME}/nldi_data.crawler_source.pgdump.gz | pg_restore -h 127.0.0.1 -p 5432 -U ${NLDI_DB_OWNER_USERNAME} -w -a -d ${NLDI_DATABASE_NAME}
-gunzip -c ${LIQUIBASE_HOME}/feature_wqp_yahara.backup.gz | pg_restore -h 127.0.0.1 -p 5432 -U ${NLDI_DB_OWNER_USERNAME} -w -a -d ${NLDI_DATABASE_NAME}
-gunzip -c ${LIQUIBASE_HOME}/feature_huc12pp_yahara.backup.gz | pg_restore -h 127.0.0.1 -p 5432 -U ${NLDI_DB_OWNER_USERNAME} -w -a -d ${NLDI_DATABASE_NAME}
-gunzip -c ${LIQUIBASE_HOME}/feature_np21_nwis_yahara.backup.gz | pg_restore -h 127.0.0.1 -p 5432 -U ${NLDI_DB_OWNER_USERNAME} -w -a -d ${NLDI_DATABASE_NAME}
+gunzip -c ${LIQUIBASE_HOME}/feature_wqp.yahara.pgdump.gz | pg_restore -h 127.0.0.1 -p 5432 -U ${NLDI_DB_OWNER_USERNAME} -w -a -d ${NLDI_DATABASE_NAME}
+gunzip -c ${LIQUIBASE_HOME}/feature_huc12pp.yahara.pgdump.gz | pg_restore -h 127.0.0.1 -p 5432 -U ${NLDI_DB_OWNER_USERNAME} -w -a -d ${NLDI_DATABASE_NAME}
+gunzip -c ${LIQUIBASE_HOME}/feature_nwissite.yahara.pgdump.gz | pg_restore -h 127.0.0.1 -p 5432 -U ${NLDI_DB_OWNER_USERNAME} -w -a -d ${NLDI_DATABASE_NAME}


### PR DESCRIPTION
- Re: #110, fix crawler_source_ids for demo database using [artifacts-2.0.0](https://github.com/internetofwater/nldi-db/releases/tag/artifacts-2.0.0)
- Update `liquibase/changeLogs/nldi/nldi_data/tables.sql` to rename `nldi_data.feature_np21_nwis` to `nldi_data.feature_nwisste`, to make the source_suffix `nldi_data.crawler_source`
- Use crawler_source from download artifact for table population. Remove `database/demo/crawler_source.tsv` and reference to [nldi_data.crawler_source.pgdump.gz ](https://github.com/internetofwater/nldi-db/releases/download/artifacts-1.0.0/nldi_data.crawler_source.pgdump.gz)